### PR TITLE
[GAUDI] Disable Gaudi CI.

### DIFF
--- a/.github/workflows/gaudi_hpu_test.yml
+++ b/.github/workflows/gaudi_hpu_test.yml
@@ -1,39 +1,39 @@
 name: 'Gaudi HPU Test Suite'
 
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - '.github/workflows/gaudi_hpu_test.yml'
-      - '.github/workflows/_gaudi_hpu_build_torch.yml'
-      - '.github/workflows/_gaudi_hpu_build_torch_hpu.yml'
-      - '.github/workflows/_gaudi_hpu_ut.yml'
-      - '.github/workflows/_gaudi_hpu_benchmark.yml'
-      - '.ci/**'
-      - 'gaudi_hpu/**'
-      - 'src/**'
-      - '!**/*.md'
-  pull_request:
-    branches:
-      - 'main'
-    paths:
-      - '.github/workflows/gaudi_hpu_test.yml'
-      - '.github/workflows/_gaudi_hpu_build_torch.yml'
-      - '.github/workflows/_gaudi_hpu_build_torch_hpu.yml'
-      - '.github/workflows/_gaudi_hpu_ut.yml'
-      - '.github/workflows/_gaudi_hpu_benchmark.yml'
-      - '.ci/**'
-      - 'gaudi_hpu/**'
-      - 'src/**'
-      - '!**/*.md'
-  release:
-    types:
-      - 'published'
-  schedule:
-    - cron: '0 12 * * *'
-  repository_dispatch:
-    types: [pytorch-nightly-event-dispatch]
+  # push:
+  #   branches:
+  #     - 'main'
+  #   paths:
+  #     - '.github/workflows/gaudi_hpu_test.yml'
+  #     - '.github/workflows/_gaudi_hpu_build_torch.yml'
+  #     - '.github/workflows/_gaudi_hpu_build_torch_hpu.yml'
+  #     - '.github/workflows/_gaudi_hpu_ut.yml'
+  #     - '.github/workflows/_gaudi_hpu_benchmark.yml'
+  #     - '.ci/**'
+  #     - 'gaudi_hpu/**'
+  #     - 'src/**'
+  #     - '!**/*.md'
+  # pull_request:
+  #   branches:
+  #     - 'main'
+  #   paths:
+  #     - '.github/workflows/gaudi_hpu_test.yml'
+  #     - '.github/workflows/_gaudi_hpu_build_torch.yml'
+  #     - '.github/workflows/_gaudi_hpu_build_torch_hpu.yml'
+  #     - '.github/workflows/_gaudi_hpu_ut.yml'
+  #     - '.github/workflows/_gaudi_hpu_benchmark.yml'
+  #     - '.ci/**'
+  #     - 'gaudi_hpu/**'
+  #     - 'src/**'
+  #     - '!**/*.md'
+  # release:
+  #   types:
+  #     - 'published'
+  # schedule:
+  #   - cron: '0 12 * * *'
+  # repository_dispatch:
+  #   types: [pytorch-nightly-event-dispatch]
   workflow_dispatch:
     inputs:
       runner:


### PR DESCRIPTION
The GAUD CI pipeline has been temporarily disabled because the required Gaudi 3 cards are not available on Intel Cloud. This change will be reverted once the necessary hardware becomes accessible.